### PR TITLE
Results: show toolbar with sort and csv export in Advanced mode

### DIFF
--- a/src/components/Results/ResultPerson.tsx
+++ b/src/components/Results/ResultPerson.tsx
@@ -20,18 +20,18 @@ const PersonListItem = styled.li<{ method: string | undefined }>`
           "Checkbox Image Stats" auto
           "Checkbox Image Actions" auto
           / 40px 68px 1fr`
-          : `"Image Account" auto
-          "Image Stats" auto
-          "Image Actions" auto
-          / 68px 1fr`};
+          : `"Checkbox Image Account" auto
+          "Checkbox Image Stats" auto
+          "Checkbox Image Actions" auto
+          / 40px 68px 1fr`};
       }
 
       @media (min-width: 768px) {
         grid-template: ${typical
           ? `"Checkbox Image Account Stats Actions" 1fr
         / 40px 68px 2fr 2fr 1fr;`
-          : `"Image Account Actions" 1fr
-        / 68px 2fr 1fr;`};
+          : `"Checkbox Image Account Actions" 1fr
+        / 40px 68px 2fr 1fr;`};
       }
     `;
   }}
@@ -197,16 +197,14 @@ export function ResultPerson({
 
   return (
     <PersonListItem method={method}>
-      {method === "typical" ? (
-        <PersonCellCheckbox>
-          <PersonCheckbox
-            disabled={loading}
-            checked={selected}
-            onChange={handleSelectedChange}
-            variant="flat"
-          />
-        </PersonCellCheckbox>
-      ) : undefined}
+      <PersonCellCheckbox>
+        <PersonCheckbox
+          disabled={loading}
+          checked={selected}
+          onChange={handleSelectedChange}
+          variant="flat"
+        />
+      </PersonCellCheckbox>
       <PersonCellImage>
         {account.avatarImageUrl || twitterUser.profileImageUrl ? (
           <PersonSocialAccountImage

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -327,9 +327,9 @@ export function Results() {
       title="Mastodon Flock"
       windowMeta={windowMeta}
     >
-      {method === "typical" ? (
-        <>
-          <Toolbar>
+      <Toolbar>
+        {method === "typical" ? (
+          <>
             <ToolbarHandle />
             <ToolbarButtonIcon
               icon="toolbarFollow"
@@ -344,47 +344,26 @@ export function Results() {
               onClick={handleUnfollowSelected}
               title="Unfollow Selected Accounts"
             />
+          </>
+        ) : undefined}
 
-            <ToolbarHandle />
-            <ToolbarIcon icon="toolbarSort" title="Sort" />
-            <ToolbarLabel>
-              <Select
-                id="sortOptions"
-                options={sortOptions}
-                value={sortValue}
-                onChange={handleSortChange}
-              />
-            </ToolbarLabel>
-            <Separator orientation="vertical" size="auto" />
-            <ToolbarButtonIcon
-              icon="toolbarExportMastodon"
-              onClick={handleExportCsv}
-              title="Download Mastodon CSV File"
-            />
-          </Toolbar>
-        </>
-      ) : (
-        <>
-          <Toolbar>
-            <ToolbarHandle />
-            <ToolbarIcon icon="toolbarSort" title="Sort" />
-            <ToolbarLabel>
-              <Select
-                id="sortOptions"
-                options={sortOptions}
-                value={sortValue}
-                onChange={handleSortChange}
-              />
-            </ToolbarLabel>
-            <Separator orientation="vertical" size="auto" />
-            <ToolbarButtonIcon
-              icon="toolbarExportMastodon"
-              onClick={handleExportCsv}
-              title="Download Mastodon CSV File"
-            />
-          </Toolbar>
-        </>
-      )}
+        <ToolbarHandle />
+        <ToolbarIcon icon="toolbarSort" title="Sort" />
+        <ToolbarLabel>
+          <Select
+            id="sortOptions"
+            options={sortOptions}
+            value={sortValue}
+            onChange={handleSortChange}
+          />
+        </ToolbarLabel>
+        <Separator orientation="vertical" size="auto" />
+        <ToolbarButtonIcon
+          icon="toolbarExportMastodon"
+          onClick={handleExportCsv}
+          title="Download Mastodon CSV File"
+        />
+      </Toolbar>
       <ScrollViewStyled shadow={false}>
         <PeopleListHeader method={method}>
           {method === "typical" ? (

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -249,7 +249,8 @@ export function Results() {
     });
   }, [results?.accounts, selectedAccountIds]);
 
-  const [sortValue = "followStatus", setSortValue] =
+  const defaultSortValue = sortOptions(method)[0].value;
+  const [sortValue = defaultSortValue, setSortValue] =
     useSearchParamsState("sortBy");
   const sortedAccounts = useMemo(() => {
     const sortOption =

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -363,7 +363,28 @@ export function Results() {
             />
           </Toolbar>
         </>
-      ) : undefined}
+      ) : (
+        <>
+          <Toolbar>
+            <ToolbarHandle />
+            <ToolbarIcon icon="toolbarSort" title="Sort" />
+            <ToolbarLabel>
+              <Select
+                id="sortOptions"
+                options={sortOptions}
+                value={sortValue}
+                onChange={handleSortChange}
+              />
+            </ToolbarLabel>
+            <Separator orientation="vertical" size="auto" />
+            <ToolbarButtonIcon
+              icon="toolbarExportMastodon"
+              onClick={handleExportCsv}
+              title="Download Mastodon CSV File"
+            />
+          </Toolbar>
+        </>
+      )}
       <ScrollViewStyled shadow={false}>
         <PeopleListHeader method={method}>
           {method === "typical" ? (

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -30,7 +30,18 @@ import { Paragraph } from "../typography/Paragraph";
 import { Window } from "../WindowManager/Window";
 import { ResultPerson } from "./ResultPerson";
 
-const sortOptions = (method: string | undefined) => [
+type SortOption = {
+  label: string;
+  value: string;
+  sort: (
+    accountLeft: AccountWithTwitter,
+    accountRight: AccountWithTwitter,
+  ) => number;
+};
+
+const sortOptions = (
+  method: string | undefined,
+): SortOption[] & { 0: SortOption } => [
   ...(method === "typical"
     ? [
         {

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -39,26 +39,7 @@ type SortOption = {
   ) => number;
 };
 
-const sortOptions = (
-  method: string | undefined,
-): SortOption[] & { 0: SortOption } => [
-  ...(method === "typical"
-    ? [
-        {
-          label: "Status",
-          value: "followStatus",
-          sort: (
-            accountLeft: AccountWithTwitter,
-            accountRight: AccountWithTwitter,
-          ) =>
-            accountLeft.following && !accountRight.following
-              ? 1
-              : !accountLeft.following && accountRight.following
-              ? -1
-              : accountLeft.name.localeCompare(accountRight.name),
-        },
-      ]
-    : []),
+const sortOptionsAlwaysAvailable: SortOption[] & { 0: SortOption } = [
   {
     label: "Name",
     value: "name",
@@ -93,6 +74,28 @@ const sortOptions = (
       (accountLeft.lastStatusAt ? Date.parse(accountLeft.lastStatusAt) : 0),
   },
 ];
+
+const sortOptions = (
+  method: string | undefined,
+): SortOption[] & { 0: SortOption } =>
+  method === "typical"
+    ? [
+        {
+          label: "Status",
+          value: "followStatus",
+          sort: (
+            accountLeft: AccountWithTwitter,
+            accountRight: AccountWithTwitter,
+          ) =>
+            accountLeft.following && !accountRight.following
+              ? 1
+              : !accountLeft.following && accountRight.following
+              ? -1
+              : accountLeft.name.localeCompare(accountRight.name),
+        },
+        ...sortOptionsAlwaysAvailable,
+      ]
+    : sortOptionsAlwaysAvailable;
 
 const ScrollViewStyled = styled(ScrollView)`
   position: relative;

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -30,17 +30,24 @@ import { Paragraph } from "../typography/Paragraph";
 import { Window } from "../WindowManager/Window";
 import { ResultPerson } from "./ResultPerson";
 
-const sortOptions = [
-  {
-    label: "Status",
-    value: "followStatus",
-    sort: (accountLeft: AccountWithTwitter, accountRight: AccountWithTwitter) =>
-      accountLeft.following && !accountRight.following
-        ? 1
-        : !accountLeft.following && accountRight.following
-        ? -1
-        : accountLeft.name.localeCompare(accountRight.name),
-  },
+const sortOptions = (method: string | undefined) => [
+  ...(method === "typical"
+    ? [
+        {
+          label: "Status",
+          value: "followStatus",
+          sort: (
+            accountLeft: AccountWithTwitter,
+            accountRight: AccountWithTwitter,
+          ) =>
+            accountLeft.following && !accountRight.following
+              ? 1
+              : !accountLeft.following && accountRight.following
+              ? -1
+              : accountLeft.name.localeCompare(accountRight.name),
+        },
+      ]
+    : []),
   {
     label: "Name",
     value: "name",
@@ -246,10 +253,11 @@ export function Results() {
     useSearchParamsState("sortBy");
   const sortedAccounts = useMemo(() => {
     const sortOption =
-      sortOptions.find((sortOption) => sortOption.value === sortValue) ??
-      sortOptions[0];
+      sortOptions(method).find(
+        (sortOption) => sortOption.value === sortValue,
+      ) ?? sortOptions(method)[0];
     return results?.accounts.sort(sortOption?.sort) ?? [];
-  }, [results?.accounts, sortValue]);
+  }, [results?.accounts, sortValue, method]);
 
   const handleSortChange = useCallback(
     (option: { value: string }) => {
@@ -352,7 +360,7 @@ export function Results() {
         <ToolbarLabel>
           <Select
             id="sortOptions"
-            options={sortOptions}
+            options={sortOptions(method)}
             value={sortValue}
             onChange={handleSortChange}
           />


### PR DESCRIPTION
Advanced mode allows the user to search for their follows without logging into mastodon, which includes users that haven’t created an account yet. Exporting to csv would be very useful for such users, since the alternative (which I ended up doing) is selecting the page content, copying it into a text editor, and reformatting things for easy searching.

This patch makes Results always show a toolbar with at least the sort and csv export tools.

_Thanks for creating this by the way, I love how cute it is, the attention to detail on the windows 95 side of things, and the fact that you even added a mode that doesn’t require logging into mastodon._