### PR TITLE
support nodeinfo returning 'hometown' as well

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,7 @@ export const config = {
   },
   mastodon: {
     minimumUpdateCacheInterval: 60 * 60 * 1000,
+    compatibleSoftwareNames: ["mastodon", "hometown"],
   },
   twitter: {
     maxResultsPerPage: 1000,

--- a/src/models/FederatedInstance.ts
+++ b/src/models/FederatedInstance.ts
@@ -51,7 +51,7 @@ const FederatedInstanceSchema = new Schema<IFederatedInstance>({
     },
   },
   software: {
-    name: { type: String, enum: ["mastodon"], required: true },
+    name: { type: String, required: true },
     version: {
       type: String,
       maxlength: 50,

--- a/src/pages/mastodon/instance-cache.ts
+++ b/src/pages/mastodon/instance-cache.ts
@@ -49,7 +49,11 @@ async function crawlUri(uri: string) {
       return { error: "badInstanceResponse" };
     }
 
-    if (!config.mastodon.compatibleSoftwareNames.includes(nodeInfoData.software.name)) {
+    if (
+      !config.mastodon.compatibleSoftwareNames.includes(
+        nodeInfoData.software.name,
+      )
+    ) {
       console.error(
         `Unsupported software on ${uri}: ${nodeInfoData.software.name} (${nodeInfoData.software.version})`,
       );

--- a/src/pages/mastodon/instance-cache.ts
+++ b/src/pages/mastodon/instance-cache.ts
@@ -49,7 +49,7 @@ async function crawlUri(uri: string) {
       return { error: "badInstanceResponse" };
     }
 
-    if (nodeInfoData.software.name !== "mastodon") {
+    if (!config.mastodon.compatibleSoftwareNames.includes(nodeInfoData.software.name)) {
       console.error(
         `Unsupported software on ${uri}: ${nodeInfoData.software.name} (${nodeInfoData.software.version})`,
       );

--- a/src/pages/mastodon/login.ts
+++ b/src/pages/mastodon/login.ts
@@ -100,7 +100,11 @@ export const get: APIRoute = async function get(context) {
         return redirectWithError("badInstanceResponse");
       }
 
-      if (nodeInfoData.software.name !== "mastodon") {
+      if (
+        !config.mastodon.compatibleSoftwareNames.includes(
+          nodeInfoData.software.name,
+        )
+      ) {
         console.error(
           `Unsupported software on ${uri}: ${nodeInfoData.software.name} (${nodeInfoData.software.version})`,
         );


### PR DESCRIPTION
Fixes #12.

Hometown identifies itself as "hometown" in the nodeinfo. I took a look and it appears that [glitch-soc](https://glitch-soc.github.io/docs/) reports itself as mastodon. Not sure if there are other forks that should be added!